### PR TITLE
Added support for circle styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,6 @@ var defaults = {
   'icon-opacity': 1,
   'icon-rotate': 0,
   'icon-size': 1,
-  'circle-radius' : 5,
   'circle-color' : '#000000',
   'circle-stroke-color' : '#000000'
 };

--- a/index.js
+++ b/index.js
@@ -36,7 +36,10 @@ var functions = {
     'text-color',
     'text-field',
     'text-font',
-    'text-halo-color'
+    'text-halo-color',
+    'circle-radius',
+    'circle-color',
+    'circle-stroke-color'
   ]
 };
 
@@ -57,7 +60,10 @@ var defaults = {
   'text-size': 16,
   'icon-opacity': 1,
   'icon-rotate': 0,
-  'icon-size': 1
+  'icon-size': 1,
+  'circle-radius' : 5,
+  'circle-color' : '#000000',
+  'circle-stroke-color' : '#000000'
 };
 
 function applyDefaults(properties) {
@@ -488,6 +494,25 @@ function getStyleFunction(glStyle, source, resolutions, onChange) {
             iconImg.setRotation(deg2rad(paint['icon-rotate'](zoom)));
             iconImg.setOpacity(paint['icon-opacity'](zoom));
             style.setZIndex(i);
+            styles[stylesLength] = style;
+          }
+        }
+
+        if (type == 'Point' && 'circle-radius' in paint) {
+          style = new ol.style.Style({
+            image: new ol.style.Circle({
+              radius: paint['circle-radius'](zoom),
+              stroke: new ol.style.Stroke({
+                color: colorWithOpacity(paint['circle-stroke-color'](zoom), opacity)
+              }),
+              fill: new ol.style.Stroke({
+                color: colorWithOpacity(paint['circle-color'](zoom), opacity)
+              })
+            })
+          });
+          if (style) {
+            style.setZIndex(i);
+            ++stylesLength;
             styles[stylesLength] = style;
           }
         }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ var functions = {
     'text-size',
     'icon-opacity',
     'icon-rotate',
-    'icon-size'
+    'icon-size',
+    'circle-radius'
   ],
   'piecewise-constant': [
     'fill-color',
@@ -37,7 +38,6 @@ var functions = {
     'text-field',
     'text-font',
     'text-halo-color',
-    'circle-radius',
     'circle-color',
     'circle-stroke-color'
   ]
@@ -500,9 +500,9 @@ function getStyleFunction(glStyle, source, resolutions, onChange) {
 
         if (type == 'Point' && 'circle-radius' in paint) {
           ++stylesLength;
-          var cache_key = paint['circle-radius'] + '.' +
-            paint['circle-stroke-color'] + '.' +
-            paint['circle-color'];
+          var cache_key = paint['circle-radius'](zoom) + '.' +
+            paint['circle-stroke-color'](zoom) + '.' +
+            paint['circle-color'](zoom);
           style = iconImageCache[cache_key];
           if(!style) {
             style = new ol.style.Style({
@@ -517,10 +517,8 @@ function getStyleFunction(glStyle, source, resolutions, onChange) {
               })
             });
           }
-          if (style) {
-            style.setZIndex(i);
-            styles[stylesLength] = style;
-          }
+          style.setZIndex(i);
+          styles[stylesLength] = style;
         }
 
         var label;

--- a/index.js
+++ b/index.js
@@ -499,20 +499,26 @@ function getStyleFunction(glStyle, source, resolutions, onChange) {
         }
 
         if (type == 'Point' && 'circle-radius' in paint) {
-          style = new ol.style.Style({
-            image: new ol.style.Circle({
-              radius: paint['circle-radius'](zoom),
-              stroke: new ol.style.Stroke({
-                color: colorWithOpacity(paint['circle-stroke-color'](zoom), opacity)
-              }),
-              fill: new ol.style.Stroke({
-                color: colorWithOpacity(paint['circle-color'](zoom), opacity)
+          ++stylesLength;
+          var cache_key = paint['circle-radius'] + '.' +
+            paint['circle-stroke-color'] + '.' +
+            paint['circle-color'];
+          style = iconImageCache[cache_key];
+          if(!style) {
+            style = new ol.style.Style({
+              image: new ol.style.Circle({
+                radius: paint['circle-radius'](zoom),
+                stroke: new ol.style.Stroke({
+                  color: colorWithOpacity(paint['circle-stroke-color'](zoom), opacity)
+                }),
+                fill: new ol.style.Stroke({
+                  color: colorWithOpacity(paint['circle-color'](zoom), opacity)
+                })
               })
-            })
-          });
+            });
+          }
           if (style) {
             style.setZIndex(i);
-            ++stylesLength;
             styles[stylesLength] = style;
           }
         }


### PR DESCRIPTION
There was no support for doing basic 'Points as Circles' rendering.  This adds support for the Mapbox GL styles that allow the user to configure those.