### PR TITLE
Fix browser crash for sources with high minzoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     {
       "name": "Torben Barsballe",
       "email": "tbarsballe@boundlessgeo.com"
+    },
+    {
+      "name": "Petr Sloup",
+      "email": "petr.sloup@klokantech.com"
     }
   ],
   "license": "BSD-2-Clause",


### PR DESCRIPTION
At the moment, if there is a source (`type: vector`) with high `minzoom` (e.g. 9) and the map is positioned to view the whole world, OpenLayers tries to load all the tiles covering the extent (it's a lot of tiles for z9 :-) ) and the browser crashes (I even had to force-restart my computer in one case).

This PR adds maxResolution to the layers where sources have `minzoom` > 0 so the rendering of such layers is skipped until appropriate. This behavior is consistent with mapbox-gl-js.