### PR TITLE
Respect existing map view

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,16 +232,15 @@ function getSourceIdByRef(layers, ref) {
   return sourceId;
 }
 
-var hasView = true;
 function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
   var view = map.getView();
-  if ('center' in glStyle && !hasView) {
+  if ('center' in glStyle && !view.getCenter()) {
     view.setCenter(proj.fromLonLat(glStyle.center));
   }
-  if ('zoom' in glStyle && !hasView) {
+  if ('zoom' in glStyle && view.getZoom() === undefined) {
     view.setZoom(glStyle.zoom);
   }
-  if (!('zoom' in glStyle || 'center' in glStyle) && !hasView) {
+  if (!view.getCenter() || view.getZoom() === undefined ) {
     view.fit(view.getProjection().getExtent(), {
       nearest: true,
       size: map.getSize()
@@ -460,7 +459,6 @@ export function apply(map, style) {
   accessToken = baseUrl = host = path = '';
 
   if (!(map instanceof Map)) {
-    hasView = false;
     map = new Map({
       target: map
     });

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
   if ('zoom' in glStyle && !hasView) {
     view.setZoom(glStyle.zoom);
   }
-  if (!('zoom' in glStyle || 'center' in glStyle)) {
+  if (!('zoom' in glStyle || 'center' in glStyle) && !hasView) {
     view.fit(view.getProjection().getExtent(), {
       nearest: true,
       size: map.getSize()


### PR DESCRIPTION
This fixes a rare case. When using `olms.apply` with existing Map object with a style that does not have `center` and `zoom`, the map view is incorrectly reset.