### PR TITLE
Convert XHR calls for sprites to fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "documentation": "^4.0.0-rc.1",
     "eslint": "^3.18.0",
     "eslint-config-openlayers": "^7.0.0",
+    "isomorphic-fetch": "^2.2.1",
     "json5": "^0.5.1",
     "mapbox-gl-styles": "^2.0.2",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
1. Converts the XHR calls for sprites to fetch.
   - Makes testing in other apps easier.
   - Creates a consistent Promise-based request chain.
2. Added 'isomorphic-fetch' dependency to shim for fetch
   when it is missing from the environment.

refs: #41 