### PR TITLE
Fetch should pass on credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ export function applyStyle(layer, glStyle, source, path) {
       var sizeFactor = spriteScale == 0.5 ? '@2x' : '';
       var spriteUrl = toSpriteUrl(glStyle.sprite, path, sizeFactor + '.json');
 
-      fetch(spriteUrl)
+      fetch(spriteUrl, {credentials: 'same-origin'})
         .then(function(response) {
           // if the response is ready return the JSON promise
           if (response.status === 200) {
@@ -130,7 +130,7 @@ export function applyStyle(layer, glStyle, source, path) {
             // return the JSON promise for the low-resolution sprites.
             sizeFactor = '';
             spriteUrl = toSpriteUrl(glStyle.sprite, path, '.json');
-            return fetch(spriteUrl).then(r => r.json());
+            return fetch(spriteUrl, {credentials: 'same-origin'}).then(r => r.json());
           }
         })
         .then(function(spritesJson) {

--- a/test/test.js
+++ b/test/test.js
@@ -126,7 +126,6 @@ describe('ol-mapbox-style', function() {
           var source = layer.getSource();
           should(source).be.instanceof(VectorTileSource);
           should(layer.getStyle()).be.a.Function();
-          should(source.getAttributions()[0].getHTML()).equal('Tegola OSM');
           done();
         });
       });


### PR DESCRIPTION
This is a follow-up to #50 we found out in our setup that sprite calls were now failing, this is because it's not passing on the credentials
Also fixed a failing test because the tegola file does not have attribution anymore.