### PR TITLE
Fix missing attributions on constructed sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
                 }
                 var tileGrid = tilejson.getTileGrid();
                 layer.setSource(new VectorTileSource({
-                  attributions: tilejson.getAttributions(),
+                  attributions: tilejson.getAttributions() || tileJSONDoc.attribution,
                   format: new MVT(),
                   tileGrid: tilegrid.createXYZ({
                     minZoom: tileGrid.getMinZoom(),


### PR DESCRIPTION
It seems that there are missing attributions on sources constructed with `processStyle` since https://github.com/openlayers/openlayers/pull/7329.

The `ol.source.TileJSON#getAttributions()` always returns null at the moment.

This PR fixes this temporarily until the next major release of OpenLayers.

It should be forward-compatible.