### PR TITLE
Add .babelrc to npm ignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 node_modules
+.babelrc


### PR DESCRIPTION
This will prevent the .babelrc from being in the node_modules
tree.