### PR TITLE
Clear cache when applyStyle gets called again

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -321,6 +321,9 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
       const layerData = layers[i];
       const layer = layerData.layer;
       const layerId = layer.id;
+      // TODO revisit when diffing gets added
+      delete functionCache[layerId];
+
       const layout = layer.layout || emptyObj;
       const paint = layer.paint || emptyObj;
       if (layout.visibility === 'none' || ('minzoom' in layer && zoom < layer.minzoom) ||

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -323,6 +323,7 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
       const layerId = layer.id;
       // TODO revisit when diffing gets added
       delete functionCache[layerId];
+      delete filterCache[layerId];
 
       const layout = layer.layout || emptyObj;
       const paint = layer.paint || emptyObj;


### PR DESCRIPTION
This fixes the sdk paint change example for now

We will need to revisit this when we add the diffing.