### PR TITLE
Always use lowercase imports as a standard to avoid duplicate modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,17 +10,17 @@ import applyStyleFunction from './stylefunction';
 import googleFonts from 'webfont-matcher/lib/fonts/google';
 import {fromLonLat} from 'ol/proj';
 import {createXYZ} from 'ol/tilegrid';
-import Map from 'ol/Map';
-import GeoJSON from 'ol/format/GeoJSON';
-import MVT from 'ol/format/MVT';
-import {unByKey} from 'ol/Observable';
-import TileLayer from 'ol/layer/Tile';
-import VectorLayer from 'ol/layer/Vector';
-import VectorTileLayer from 'ol/layer/VectorTile';
-import TileJSON from 'ol/source/TileJSON';
-import VectorSource from 'ol/source/Vector';
-import VectorTileSource from 'ol/source/VectorTile';
-import XYZ from 'ol/source/XYZ';
+import Map from 'ol/map';
+import GeoJSON from 'ol/format/geojson';
+import MVT from 'ol/format/mvt';
+import {unByKey} from 'ol/observable';
+import TileLayer from 'ol/layer/tile';
+import VectorLayer from 'ol/layer/vector';
+import VectorTileLayer from 'ol/layer/vectortile';
+import TileJSON from 'ol/source/tilejson';
+import VectorSource from 'ol/source/vector';
+import VectorTileSource from 'ol/source/vectortile';
+import XYZ from 'ol/source/xyz';
 
 var availableFonts;
 

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -4,13 +4,13 @@ Copyright 2016-present Boundless Spatial, Inc.
 License: https://raw.githubusercontent.com/boundlessgeo/ol-mapbox-gl-style/master/LICENSE
 */
 
-import Style from 'ol/style/Style';
-import Fill from 'ol/style/Fill';
-import Stroke from 'ol/style/Stroke';
-import Icon from 'ol/style/Icon';
-import Text from 'ol/style/Text';
-import Circle from 'ol/style/Circle';
-import Point from 'ol/geom/Point';
+import Style from 'ol/style/style';
+import Fill from 'ol/style/fill';
+import Stroke from 'ol/style/stroke';
+import Icon from 'ol/style/icon';
+import Text from 'ol/style/text';
+import Circle from 'ol/style/circle';
+import Point from 'ol/geom/point';
 import derefLayers from '@mapbox/mapbox-gl-style-spec/deref';
 import glfun from '@mapbox/mapbox-gl-style-spec/function';
 import createFilter from '@mapbox/mapbox-gl-style-spec/feature_filter';


### PR DESCRIPTION
Switch all Openlayers imports to be lowercase to ensure bundlers (e.g. Webpack4 in our case) can tree-shake and JS modules are not duplicated.

This was a problem for us because we use lowercase imports throughout our codebase and even some external modules outside of our control (e.g. https://github.com/Viglino/ol-ext/blob/master/src/interaction/Transform.js).

An example of the webpack errors we had:
```
errors @ webpack-dev-server.js:1
webpack-dev-server.js:1 ./node_modules/ol-mapbox-style/stylefunction.js
Module not found: Error: Can't resolve 'ol/geom/Point' in '/home/csnyders/wrq/webapp2/node_modules/ol-mapbox-style'
errors @ webpack-dev-server.js:1
webpack-dev-server.js:1 ./node_modules/ol-mapbox-style/stylefunction.js
Module not found: Error: Can't resolve 'ol/style/Circle' in '/home/csnyders/wrq/webapp2/node_modules/ol-mapbox-style'
```