### PR TITLE
Avoid keeping a reference to the OpenLayers Map

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -234,6 +234,7 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
       spriteImage = img;
       spriteImgSize = [img.width, img.height];
       olLayer.changed();
+      img.onload = null;
     };
     img.src = spriteImageUrl;
   }


### PR DESCRIPTION
Currently the closure for `img.onload` keeps a reference to `olLayer`. This prevents OpenLayers Map from being garbage collected even if the Map is not used anywhere else. The full retaining path looks something like this:
```
OpenLayers shared IconImageCache -> IconImage -> img in this project -> onload closure -> layer -> ... -> Map. 
```