### PR TITLE
Use transpiled imports from mapbox-gl-style-spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ import TileJSON from 'ol/source/TileJSON';
 import VectorSource from 'ol/source/Vector';
 import VectorTileSource from 'ol/source/VectorTile';
 import XYZ from 'ol/source/XYZ';
-import Color from '@mapbox/mapbox-gl-style-spec/util/color';
+import {Color} from '@mapbox/mapbox-gl-style-spec';
 
 var fontFamilyRegEx = /font-family: ?([^;]*);/;
 var stripQuotesRegEx = /("|')/g;

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -13,15 +13,18 @@ import Circle from 'ol/style/Circle';
 import Point from 'ol/geom/Point';
 import derefLayers from '@mapbox/mapbox-gl-style-spec/deref';
 import spec from '@mapbox/mapbox-gl-style-spec/reference/latest';
-import {isFunction} from '@mapbox/mapbox-gl-style-spec/function';
-import {isExpression} from '@mapbox/mapbox-gl-style-spec/expression';
-import convertFunction from '@mapbox/mapbox-gl-style-spec/function/convert';
-import Color from '@mapbox/mapbox-gl-style-spec/util/color';
-import {createPropertyExpression} from '@mapbox/mapbox-gl-style-spec/expression';
-
-import createFilter from '@mapbox/mapbox-gl-style-spec/feature_filter';
+import {
+  expression, Color,
+  function as fn,
+  featureFilter as createFilter
+} from '@mapbox/mapbox-gl-style-spec';
 import mb2css from 'mapbox-to-css-font';
 import {deg2rad, getZoomForResolution} from './util';
+
+const isFunction = fn.isFunction;
+const convertFunction = fn.convertFunction;
+const isExpression = expression.isExpression;
+const createPropertyExpression = expression.createPropertyExpression;
 
 const types = {
   'Point': 1,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,13 +86,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        loader: 'babel-loader',
-        query: {
-          cacheDirectory: true
-        }
-      },
-      {
         test: /\.css$/,
         use: ['style-loader', 'css-loader']
       }

--- a/webpack.config.olms.js
+++ b/webpack.config.olms.js
@@ -32,16 +32,5 @@ module.exports = {
     'ol/source/Vector': 'ol.source.Vector',
     'ol/source/VectorTile': 'ol.source.VectorTile',
     'ol/source/XYZ': 'ol.source.XYZ'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        loader: 'babel-loader',
-        query: {
-          cacheDirectory: true
-        }
-      }
-    ]
   }
 };


### PR DESCRIPTION
This pull request replaces #92.

The downside is that all bundles created from `ol-mapbox-style` will be larger by 10 kB than with the source imports we previously used.

For `create-react-app` users, we should consider making that work with ES modules, which it maybe already does in the latest alpha version. See facebook/create-react-app#3889.

That said, I'm not sure if we want to merge this. @bartvde @frankrowe what do you think?