### PR TITLE
updated webpack & webpack-cli to current versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
     "should": "^11.2.1",
     "should-approximately-deep": "^1.1.0",
     "style-loader": "^0.20.3",
-    "webpack": "^4.12.0",
-    "webpack-cli": "^2.1.5",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.1"
   },
   "jest": {


### PR DESCRIPTION
When I tried to run the tests, I was getting the following error during build:

```
> ol-mapbox-style@3.0.1 build /Users/fleur/work/rug/ol-mapbox-style
> webpack-cli --config ./webpack.config.olms.js && webpack-cli

/Users/fleur/work/rug/ol-mapbox-style/node_modules/webpack-cli/bin/config-yargs.js:89
				describe: optionsSchema.definitions.output.properties.path.description,
				                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/Users/fleur/work/rug/ol-mapbox-style/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at /Users/fleur/work/rug/ol-mapbox-style/node_modules/webpack-cli/bin/webpack.js:60:27
    at Object.<anonymous> (/Users/fleur/work/rug/ol-mapbox-style/node_modules/webpack-cli/bin/webpack.js:515:3)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
```
The fix was upgrading the npm packages `webpack` and `webpack-cli`.