### PR TITLE
updated @mapbox/mapbox-gl-style-spec 

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "mapbox-gl-styles": "^2.0.2",
     "mkdirp": "^0.5.1",
     "nock": "^10.0.1",
+    "nodemon": "^1.18.5",
     "ol": "^5.0.0",
     "regenerator-runtime": "^0.12.1",
     "should": "^13.2.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "BSD-2-Clause",
   "scripts": {
-    "start": "webpack-dev-server --config ./webpack.config.js",
+    "start": "nodemon --watch webpack.config.js --exec \"webpack-dev-server --config ./webpack.config.js --inline --mode=development\"",
     "prepare": "npm run doc && npm run build",
     "build": "webpack-cli --config ./webpack.config.olms.js && webpack-cli",
     "doc": "documentation readme -s API index.js",
@@ -70,7 +70,7 @@
     "cover": "jest --coverage"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-style-spec": "^12.0.0",
+    "@mapbox/mapbox-gl-style-spec": "^13.3.0",
     "mapbox-to-css-font": "^2.2.0",
     "webfont-matcher": "^1.1.0"
   },

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -14,7 +14,8 @@ import Point from 'ol/geom/Point';
 import derefLayers from '@mapbox/mapbox-gl-style-spec/deref';
 import spec from '@mapbox/mapbox-gl-style-spec/reference/latest';
 import {
-  expression, Color,
+  expression,
+  Color,
   function as fn,
   featureFilter as createFilter
 } from '@mapbox/mapbox-gl-style-spec';
@@ -66,7 +67,9 @@ export function getValue(layer, layoutOrPaint, property, zoom, feature) {
     let value = (layer[layoutOrPaint] || emptyObj)[property];
     const propertySpec = spec[`${layoutOrPaint}_${layer.type}`][property];
     if (value === undefined) {
-      value = propertySpec.default;
+      value = (propertySpec.default !== undefined) ? propertySpec.default : 'none';
+    } else if ((typeof value == 'object') && !('default' in value)) {
+      value.default = (propertySpec.default !== undefined) ? propertySpec.default : '';
     }
     let isExpr = isExpression((value));
     if (!isExpr && isFunction(value)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = {
       'ol-mapbox-style': path.resolve(__dirname, '.')
     }
   },
-  devtool: 'source-map',
+  devtool: 'eval-source-map',
   node: {fs: 'empty'},
   module: {
     rules: [


### PR DESCRIPTION
Hi.  I didn't do this earlier because it broke something, and now I've gone back and figured it out.  The problem is that `@mapbox/mapbox-gl-style-spec`  doesn't handle missing property defaults gracefully any more.

It used to be that compiling an expression that had `undefined` for a default would not fail, but it does now.  Not all elements in the stylespec reference have defaults to fall back on, which is what `ol-mapbox-style` was doing if there were no properties at all.  Now even existing properties passed w/o a default will error out, hence the extra if.

I'm pretty sure this is all there is to it, but my domain knowledge is lacking, so definitely sanity check me.  Tests pass, examples work.

Also added nodemon.