### PR TITLE
added tests for some utility functions defined in stylefunction.js

### DIFF
--- a/__tests__/applyStyle.test.js
+++ b/__tests__/applyStyle.test.js
@@ -57,8 +57,7 @@ describe('applyStyle style argument validation', function() {
   });
 
   test('should reject invalid ol layer type', function(done) {
-    const layer = new ImageLayer();
-    applyStyle(layer, glStyle, source).then(function() {
+    applyStyle(new ImageLayer(), glStyle, source).then(function() {
       done(new Error('invalid ol layer type promise should reject'));
     }).catch(function(err) {
       done();
@@ -66,10 +65,7 @@ describe('applyStyle style argument validation', function() {
   });
 
   test('should reject invalid ol layer source type', function(done) {
-    const source = 'natural_earth_shaded_relief';
-    const layer = new VectorLayer();
-
-    applyStyle(layer, glStyle, source).then(function() {
+    applyStyle(new VectorLayer(), glStyle, 'natural_earth_shaded_relief').then(function() {
       done(new Error('invalid ol layer source promise should reject'));
     }).catch(function(err) {
       done();

--- a/__tests__/stylefunction-utils.test.js
+++ b/__tests__/stylefunction-utils.test.js
@@ -1,5 +1,5 @@
 /*eslint no-console: "off"*/
-import should from 'should/as-function';
+import should from 'should';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 import {Color} from '@mapbox/mapbox-gl-style-spec';
@@ -112,10 +112,6 @@ describe('utility functions currently in stylefunction.js', function() {
       },
       'type': 'line'
     };
-
-    test('should handle invalid property', function() {
-      should(getValue(glLayer2, 'layout', 'symbol', zoom, feature)).be.undefined;
-    });
 
     test('should get correct default property', function() {
       const d = spec['layout_line']['line-cap']['default'];

--- a/__tests__/stylefunction-utils.test.js
+++ b/__tests__/stylefunction-utils.test.js
@@ -1,0 +1,147 @@
+/*eslint no-console: "off"*/
+import should from 'should/as-function';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import {Color} from '@mapbox/mapbox-gl-style-spec';
+import spec from '@mapbox/mapbox-gl-style-spec/reference/latest';
+
+
+const stylefunction = require('../stylefunction');
+
+
+describe('utility functions currently in stylefunction.js', function() {
+
+  describe('evaluateFilter()', function() {
+    const filterCache = stylefunction.__get__('filterCache');
+    const evaluateFilter = stylefunction.__get__('evaluateFilter');
+    const feature = new Feature({geometry: new Point([0, 0], 'XY')});
+    const zoom = 11;
+
+    test('should be true with "all" filter', function() {
+      const glLayerId = 'gl-layer-id';
+      const filter = '[ "all" ]';
+
+      should(filterCache).not.have.key(glLayerId);
+      should(evaluateFilter(glLayerId, filter, feature, zoom)).be.true;
+      should(filterCache).have.key(glLayerId);
+    });
+
+    test('should be false with LineString filter and Point geom', function() {
+      const glLayerId = 'gl-layer-id-2';
+      const filter = '[ "==", "$type", "LineString" ]';
+
+      should(evaluateFilter(glLayerId, filter, feature, zoom)).be.false;
+      should(filterCache).have.key(glLayerId);
+    });
+
+    test('should be true with Point filter and Point geom', function() {
+      const glLayerId = 'gl-layer-id-2';
+      const filter = '[ "==", "$type", "Point" ]';
+
+      should(evaluateFilter(glLayerId, filter, feature, zoom)).be.false;
+      should(filterCache).have.key(glLayerId);
+    });
+
+  });
+
+  describe('fromTemplate()', function() {
+    const fromTemplate = stylefunction.__get__('fromTemplate');
+    const props = {de: 'BLAH', fun: 'not fun'};
+
+    test('should replace single template string', function() {
+      const tmpl = 'blah, blah, blah {de} blah';
+      should.equal(tmpl.replace('{de}', 'BLAH'), fromTemplate(tmpl, props));
+    });
+
+    test('should replace two subs in template string', function() {
+      const tmpl = 'blah, blah, blah {de} blah fun fun {fun}';
+      should.equal(tmpl.replace('{de}', 'BLAH').replace('{fun}', 'not fun'), fromTemplate(tmpl, props));
+    });
+
+    test('should handle templates with no subs', function() {
+      const tmpl = 'blah, blah, blah de blah fun fun fun';
+      should.equal(tmpl, fromTemplate(tmpl, props));
+    });
+
+    test('should remove subs with no matching properties', function() {
+      const tmpl = 'blah, blah, {what}blah de blah fun fun fun';
+      const result = 'blah, blah, blah de blah fun fun fun';
+      should.equal(result, fromTemplate(tmpl, props));
+    });
+
+    test('should handle minorly misshapen subs', function() {
+      const tmpl = 'blah, blah, blah {de blah fun {fun} fun';
+      should.equal(tmpl.replace('{fun}', 'not fun'), fromTemplate(tmpl, props));
+    });
+
+  });
+
+
+  describe('getValue()', function() {
+    const getValue = stylefunction.__get__('getValue');
+    const functionCache = stylefunction.__get__('functionCache');
+    const zoom = 11;
+    const feature = new Feature({geometry: new Point([0, 0], 'XY')});
+    const glLayer = {
+      'id': 'landuse-residential',
+      'layout': {
+        'visibility': 'visible'
+      },
+      'paint': {
+        'fill-color': 'rgba(192, 216, 151, 0.53)',
+        'fill-opacity': 0.7
+      },
+      'type': 'fill'
+    };
+    const glLayer2 = {
+      'id': 'park_outline',
+      'paint': {
+        'line-color': 'rgba(159, 183, 118, 0.69)',
+        'line-gap-width': {
+          'stops': [
+            [
+              12,
+              0
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      'type': 'line'
+    };
+
+    test('should handle invalid property', function() {
+      should(getValue(glLayer2, 'layout', 'symbol', zoom, feature)).be.undefined;
+    });
+
+    test('should get correct default property', function() {
+      const d = spec['layout_line']['line-cap']['default'];
+
+      should.equal(getValue(glLayer2, 'layout', 'line-cap', zoom, feature), d);
+      should(functionCache).have.key(glLayer2.id);
+    });
+
+    test('should get simple layout property', function() {
+      should.equal(getValue(glLayer, 'layout', 'visibility', zoom, feature), 'visible');
+      should(functionCache).have.key(glLayer.id);
+    });
+
+    test('should get simple paint property', function() {
+      should.equal(getValue(glLayer, 'paint', 'fill-opacity', zoom, feature), 0.7);
+    });
+
+    test('should get color paint property', function() {
+      const result = getValue(glLayer, 'paint', 'fill-color', zoom, feature);
+      should(result).be.instanceof(Color);
+    });
+
+    test('should get complex paint property', function() {
+      const result = getValue(glLayer2, 'paint', 'line-gap-width', 20, feature);
+      should(result).equal(6);
+    });
+
+  });
+});

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -65,7 +65,7 @@ export function getValue(layer, layoutOrPaint, property, zoom, feature) {
   if (!functions[property]) {
     let value = (layer[layoutOrPaint] || emptyObj)[property];
     const propertySpec = spec[`${layoutOrPaint}_${layer.type}`][property];
-    if ((value === undefined) && propertySpec) {
+    if (value === undefined) {
       value = propertySpec.default;
     }
     let isExpr = isExpression((value));
@@ -77,7 +77,7 @@ export function getValue(layer, layoutOrPaint, property, zoom, feature) {
       const compiledExpression = expressionData(value, propertySpec);
       functions[property] = compiledExpression.evaluate.bind(compiledExpression);
     } else {
-      if (propertySpec && (propertySpec.type == 'color')) {
+      if (propertySpec.type == 'color') {
         value = Color.parse(value);
       }
       functions[property] = function() {

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -65,7 +65,7 @@ export function getValue(layer, layoutOrPaint, property, zoom, feature) {
   if (!functions[property]) {
     let value = (layer[layoutOrPaint] || emptyObj)[property];
     const propertySpec = spec[`${layoutOrPaint}_${layer.type}`][property];
-    if (value === undefined) {
+    if ((value === undefined) && propertySpec) {
       value = propertySpec.default;
     }
     let isExpr = isExpression((value));
@@ -77,7 +77,7 @@ export function getValue(layer, layoutOrPaint, property, zoom, feature) {
       const compiledExpression = expressionData(value, propertySpec);
       functions[property] = compiledExpression.evaluate.bind(compiledExpression);
     } else {
-      if (propertySpec.type == 'color') {
+      if (propertySpec && (propertySpec.type == 'color')) {
         value = Color.parse(value);
       }
       functions[property] = function() {


### PR DESCRIPTION
I'm writing tests as I'm learning the codebase, if you'd like to incorporate them.  I inadvertently checked in a bit of code tightening up I did in `__tests__/applyStyle.test.js`, which aren't needed.  I can remove that if you like.  Also minor error handling improvement to `getValue()`.