### PR TITLE
Do not set z-index on layers

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,9 +437,7 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
         }
         glSourceId = id;
         if (layer) {
-          layer.setZIndex(i);
           layer.set('mapbox-source', glSourceId);
-          layer.set('mapbox-layers', layerIds);
         }
       }
       layerIds.push(glLayer.id);
@@ -617,6 +615,7 @@ function finalizeLayer(layer, layerIds, glStyle, path, map) {
       }
     };
 
+    layer.set('mapbox-layers', layerIds);
     if (map.getLayers().getArray().indexOf(layer) === -1) {
       map.addLayer(layer);
     }


### PR DESCRIPTION
This pull request removes the z-index from the OpenLayers layers that the library creates. This improves interoperability in cases where users add layers to their map that are not handled by the library.

Fixes #119.